### PR TITLE
Update broken links and add missing metric definition files

### DIFF
--- a/detail_metrics_methods/issues-closed-contributor-new.md
+++ b/detail_metrics_methods/issues-closed-contributor-new.md
@@ -1,0 +1,18 @@
+# New Contributor Closed Issues
+
+## 1. Description
+What is the number of new contributors who are closing issues?
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/detail_metrics_methods/pull-request-comments.md
+++ b/detail_metrics_methods/pull-request-comments.md
@@ -1,0 +1,18 @@
+# New Contributors of Code Reviews
+
+## 1. Description
+What is the number of persons contributing with reviews of code for the first time?
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/detail_metrics_methods/pull-requests-closed.md
+++ b/detail_metrics_methods/pull-requests-closed.md
@@ -1,0 +1,18 @@
+# Pull Requests Closed
+
+## 1. Description
+What is the number of closed pull requests?
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/detail_metrics_methods/pull-requests-code-reviews.md
+++ b/detail_metrics_methods/pull-requests-code-reviews.md
@@ -1,0 +1,18 @@
+# Number of Code Reviews
+
+## 1. Description
+What is the number of code reviews?
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/detail_metrics_methods/pull-requests-maintainer-response-duration.md
+++ b/detail_metrics_methods/pull-requests-maintainer-response-duration.md
@@ -1,0 +1,18 @@
+# Maintainer Response Duration
+
+## 1. Description
+On average, how long does it take for a maintainer to respond to a pull request?
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/detail_metrics_methods/pull-requests-merged-vs-closed.md
+++ b/detail_metrics_methods/pull-requests-merged-vs-closed.md
@@ -1,0 +1,18 @@
+# Merged vs. Closed Pull Requests
+
+## 1. Description
+What is the ratio/relationship of closed and merged pull requests? 
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/detail_metrics_methods/pull-requests-reviews-contributors-new.md
+++ b/detail_metrics_methods/pull-requests-reviews-contributors-new.md
@@ -1,0 +1,18 @@
+# New Contributors Pull Requests
+
+## 1. Description
+What is the number of new contributors opening pull requests?
+
+## 2. Use Cases
+
+## 3. Formula
+
+## 4. Sample Filter and Visualization
+
+## 5. Sample Implementation
+
+## 6. Known Implementations
+
+## 7. Test Cases (Examples)
+
+## 8. External References (Literature)

--- a/focus_areas/code_development/goal_code_development.md
+++ b/focus_areas/code_development/goal_code_development.md
@@ -4,19 +4,19 @@ Goal: Identify how effective the community is at merging new code into the codeb
 
 Metric | Question
 --- | ---
-[Pull Requests Merged](detail_metrics_methods/code_development/pull-requests-merged.md) | What is the number of code commits?
-[Lines of Code Changed](detail_metrics_methods/code_development/pull-requests-lines-of-code-changed.md) | What is the number of lines of code changed?
-[Code Reviews](detail_metrics_methods/code_development/pull-requests-code-reviews.md) | What is the number of code reviews?
-[Pull Request Merge Duration](detail_metrics_methods/code_development/pull-requests-merge-duration.md) | What is the duration of time between code merge request and code commit?
-[Code Review Efficiency](detail_metrics_methods/code_development/pull-requests-review-efficiency.md) | What is the number of merged code changes/number of abandoned code change requests?
-[Maintainer Response to Merge Request Duration](detail_metrics_methods/code_development/pull-requests-maintainer-response-duration.md) | What is the duration of time for a maintainer to make a first response to a code merge request?
-[Code Review Iteration](detail_metrics_methods/code_development/pull-requests-review-iteration.md) | What is the number of iterations that occur before a merge request is accepted or declined?
-[Forks](detail_metrics_methods/code_development/forks.md) | Forks are a concept in distributed version control systems like GitHub. It is a proxy for the approximate number of developers who have taken a shot at building and deploying the codebase *for development*.
-[Pull Requests Open](detail_metrics_methods/code_development/pull-requests-open.md) | Number of open pull requests.
-[Pull Requests Closed](detail_metrics_methods/code_development/pull-requests-closed.md) | Number of closed pull requests.
-[Pull Request Comment Duration](detail_metrics_methods/code_development/pull-requests-comment-duration.md) | The difference between the timestamp of the pull request creation date and the most recent comment on the pull request.
-[Pull Request Comment Diversity](detail_metrics_methods/code_development/pull-requests-participants.md) | Number of each people discussing each pull request.
-[Pull Request Comments](detail_metrics_methods/code_development/pull-request-comments.md) | Number of comments on each pull request.
+[Pull Requests Merged](../../detail_metrics_methods/pull-requests-merged.md) | What is the number of code commits?
+[Lines of Code Changed](../../detail_metrics_methods/pull-requests-lines-of-code-changed.md) | What is the number of lines of code changed?
+[Code Reviews](../../detail_metrics_methods/pull-requests-code-reviews.md) | What is the number of code reviews?
+[Pull Request Merge Duration](../../detail_metrics_methods/pull-requests-merge-duration.md) | What is the duration of time between code merge request and code commit?
+[Code Review Efficiency](../../detail_metrics_methods/pull-requests-review-efficiency.md) | What is the number of merged code changes/number of abandoned code change requests?
+[Maintainer Response to Merge Request Duration](../../detail_metrics_methods/pull-requests-maintainer-response-duration.md) | What is the duration of time for a maintainer to make a first response to a code merge request?
+[Code Review Iteration](../../detail_metrics_methods/pull-requests-review-iteration.md) | What is the number of iterations that occur before a merge request is accepted or declined?
+[Forks](../../detail_metrics_methods/forks.md) | Forks are a concept in distributed version control systems like GitHub. It is a proxy for the approximate number of developers who have taken a shot at building and deploying the codebase *for development*.
+[Pull Requests Open](../../detail_metrics_methods/pull-requests-open.md) | Number of open pull requests.
+[Pull Requests Closed](../../detail_metrics_methods/pull-requests-closed.md) | Number of closed pull requests.
+[Pull Request Comment Duration](../../detail_metrics_methods/pull-requests-comment-duration.md) | The difference between the timestamp of the pull request creation date and the most recent comment on the pull request.
+[Pull Request Comment Diversity](../../detail_metrics_methods/pull-requests-participants.md) | Number of each people discussing each pull request.
+[Pull Request Comments](../../detail_metrics_methods/pull-request-comments.md) | Number of comments on each pull request.
 
 **Disclaimer:**
 The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Growth-Maturity-Decline.

--- a/focus_areas/community_growth/goal_community_growth.md
+++ b/focus_areas/community_growth/goal_community_growth.md
@@ -4,18 +4,18 @@ Goal: Identify the size of the project community and whether it's growing, shrin
 
 Metric | Quesiton
 --- | ---
-[Contributors](detail_metrics_methods/contributors.md) | What is the number of contributors?
-[New Overall Contributors](detail_metrics_methods/contributors-new.md) | What is the overall number of new contributors?
-[New Contributors of Commits](detail_metrics_methods/pull-requests-merge-contributor-new.md) | What is the number of persons contributing with an accepted commit for the first time?
-[New Contributors of Opened Issues](detail_metrics_methods/issues-open-contributor-new.md) | What is the number of persons opening an issue for the first time?
-[New Contributors of Closed Issues](detail_metrics_methods/issues-closed-contributor-new.md) | What is the number of persons closing an issue for the first time?
-[New Contributors of Initiated Code Reviews](detail_metrics_methods/pull-requests-initiated-reviews-contributors-new.md) | What is the number of persons initiating a code review for the first time?
-[New Contributors of Reviews for Code](detail_metrics_methods/pull-requests-reviews-contributors-new.md) | What is the number of persons contributing with reviews of code for the first time?
-[New Contributors of Posted Messages](detail_metrics_methods/mailing-lists-messages-contributors-new.md) | What is the number of persons posting messages in mailing lists for the first time?
-[Contributing Organizations](detail_metrics_methods/organizations.md) | What is the number of contributing organizations?
-[New Contributing Organizations](detail_metrics_methods/organizations-new.md) | What is the number of new contributing organizations?
-[Sub-Projects](detail_metrics_methods/sub-projects.md) | What is the number of sub-projects?
-[Contribution Acceptance](detail_metrics_methods/pull-requests-merged-vs-closed.md)  | Ratio of contributions accepted vs. closed without acceptance
+[Contributors](../../detail_metrics_methods/contributors.md) | What is the number of contributors?
+[New Overall Contributors](../../detail_metrics_methods/contributors-new.md) | What is the overall number of new contributors?
+[New Contributors of Commits](../../detail_metrics_methods/pull-requests-merge-contributor-new.md) | What is the number of persons contributing with an accepted commit for the first time?
+[New Contributors of Opened Issues](../../detail_metrics_methods/issues-open-contributor-new.md) | What is the number of persons opening an issue for the first time?
+[New Contributors of Closed Issues](../../detail_metrics_methods/issues-closed-contributor-new.md) | What is the number of persons closing an issue for the first time?
+[New Contributors of Initiated Code Reviews](../../detail_metrics_methods/pull-requests-initiated-reviews-contributors-new.md) | What is the number of persons initiating a code review for the first time?
+[New Contributors of Reviews for Code](../../detail_metrics_methods/pull-requests-reviews-contributors-new.md) | What is the number of persons contributing with reviews of code for the first time?
+[New Contributors of Posted Messages](../../detail_metrics_methods/mailing-lists-messages-contributors-new.md) | What is the number of persons posting messages in mailing lists for the first time?
+[Contributing Organizations](../../detail_metrics_methods/organizations.md) | What is the number of contributing organizations?
+[New Contributing Organizations](../../detail_metrics_methods/organizations-new.md) | What is the number of new contributing organizations?
+[Sub-Projects](../../detail_metrics_methods/sub-projects.md) | What is the number of sub-projects?
+[Contribution Acceptance](../../detail_metrics_methods/pull-requests-merged-vs-closed.md)  | Ratio of contributions accepted vs. closed without acceptance
 
 
 **Disclaimer:**

--- a/focus_areas/community_growth/goal_community_growth.md
+++ b/focus_areas/community_growth/goal_community_growth.md
@@ -4,18 +4,18 @@ Goal: Identify the size of the project community and whether it's growing, shrin
 
 Metric | Quesiton
 --- | ---
-[Contributors](detail_metrics_methods/community_growth/contributors.md) | What is the number of contributors?
-[New Overall Contributors](detail_metrics_methods/community_growth/contributors-new.md) | What is the overall number of new contributors?
-[New Contributors of Commits](detail_metrics_methods/community_growth/pull-requests-merge-contributor-new.md) | What is the number of persons contributing with an accepted commit for the first time?
-[New Contributors of Opened Issues](detail_metrics_methods/community_growth/issues-open-contributor-new.md) | What is the number of persons opening an issue for the first time?
-[New Contributors of Closed Issues](detail_metrics_methods/community_growth/issues-closed-contributor-new.md) | What is the number of persons closing an issue for the first time?
-[New Contributors of Initiated Code Reviews](detail_metrics_methods/community_growth/pull-requests-initiated-reviews-contributors-new.md) | What is the number of persons initiating a code review for the first time?
-[New Contributors of Reviews for Code](detail_metrics_methods/community_growth/pull-requests-reviews-contributors-new.md) | What is the number of persons contributing with reviews of code for the first time?
-[New Contributors of Posted Messages](detail_metrics_methods/community_growth/mailing-lists-messages-contributors-new.md) | What is the number of persons posting messages in mailing lists for the first time?
-[Contributing Organizations](detail_metrics_methods/community_growth/organizations.md) | What is the number of contributing organizations?
-[New Contributing Organizations](detail_metrics_methods/community_growth/organizations-new.md) | What is the number of new contributing organizations?
-[Sub-Projects](detail_metrics_methods/community_growth/sub-projects.md) | What is the number of sub-projects?
-[Contribution Acceptance](detail_metrics_methods/community_growth/pull-requests-merged-vs-closed.md)  | Ratio of contributions accepted vs. closed without acceptance
+[Contributors](detail_metrics_methods/contributors.md) | What is the number of contributors?
+[New Overall Contributors](detail_metrics_methods/contributors-new.md) | What is the overall number of new contributors?
+[New Contributors of Commits](detail_metrics_methods/pull-requests-merge-contributor-new.md) | What is the number of persons contributing with an accepted commit for the first time?
+[New Contributors of Opened Issues](detail_metrics_methods/issues-open-contributor-new.md) | What is the number of persons opening an issue for the first time?
+[New Contributors of Closed Issues](detail_metrics_methods/issues-closed-contributor-new.md) | What is the number of persons closing an issue for the first time?
+[New Contributors of Initiated Code Reviews](detail_metrics_methods/pull-requests-initiated-reviews-contributors-new.md) | What is the number of persons initiating a code review for the first time?
+[New Contributors of Reviews for Code](detail_metrics_methods/pull-requests-reviews-contributors-new.md) | What is the number of persons contributing with reviews of code for the first time?
+[New Contributors of Posted Messages](detail_metrics_methods/mailing-lists-messages-contributors-new.md) | What is the number of persons posting messages in mailing lists for the first time?
+[Contributing Organizations](detail_metrics_methods/organizations.md) | What is the number of contributing organizations?
+[New Contributing Organizations](detail_metrics_methods/organizations-new.md) | What is the number of new contributing organizations?
+[Sub-Projects](detail_metrics_methods/sub-projects.md) | What is the number of sub-projects?
+[Contribution Acceptance](detail_metrics_methods/pull-requests-merged-vs-closed.md)  | Ratio of contributions accepted vs. closed without acceptance
 
 
 **Disclaimer:**

--- a/focus_areas/issue_resolution/goal_Issue_resolution.md
+++ b/focus_areas/issue_resolution/goal_Issue_resolution.md
@@ -4,12 +4,12 @@ Goal: Identify how effective the community is at addressing issues identified by
 
 Metric | Question
 --- | ---
-[Open Issues](detail_metrics_methods/issue_resolution/issues-open.md) | What is the number of open issues?
-[Closed Issues](detail_metrics_methods/issue_resolution/issues-closed.md) | What is the number of closed issues?
-[Open Issue Age](detail_metrics_methods/issue_resolution/issues-open-age.md) | What is the the age of open issues?
-[First Response to Issue Duration](detail_metrics_methods/issue_resolution/issues-maintainer-response-duration.md) | What is the duration of time for a first response to an issue?
-[Closed Issue Resolution Duration](detail_metrics_methods/issue_resolution/issues-closed-resolution-duration.md) | What is the duration of time for issues to be resolved?
-[Issue Resolution Efficiency](detail_metrics_methods/issue_resolution/issues-closed-resolution-efficiency.md) |  What is the ratio of closed issues/number of abandoned issues?
+[Open Issues](../../detail_metrics_methods/issues-open.md) | What is the number of open issues?
+[Closed Issues](../../detail_metrics_methods/issues-closed.md) | What is the number of closed issues?
+[Open Issue Age](../../detail_metrics_methods/issues-open-age.md) | What is the the age of open issues?
+[First Response to Issue Duration](../../detail_metrics_methods/issues-maintainer-response-duration.md) | What is the duration of time for a first response to an issue?
+[Closed Issue Resolution Duration](../../detail_metrics_methods/issues-closed-resolution-duration.md) | What is the duration of time for issues to be resolved?
+[Issue Resolution Efficiency](../../detail_metrics_methods/issues-closed-resolution-efficiency.md) |  What is the ratio of closed issues/number of abandoned issues?
 
 **Disclaimer:**
 The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Growth-Maturity-Decline.


### PR DESCRIPTION
All broken links pointing to locations that no longer exist under the current project directory structure have been updated to point to their new locations.

Specifically, now that all of the metrics in `details_metrics_methods` are no longer in the folder of their respective goal, all of the goal pages pointing to those metrics have been updated to reflect that change. Additionally, several metrics that did not have definition files now have definition files. 